### PR TITLE
Added missing fields to ifaddrs struct on Android

### DIFF
--- a/src/ifaces/ffi/android/ifaddrs.cpp
+++ b/src/ifaces/ffi/android/ifaddrs.cpp
@@ -42,8 +42,12 @@ struct ifaddrs {
     sockaddr* ifa_addr;
     // Interface netmask.
     sockaddr* ifa_netmask;
+    // Unused
+    sockaddr* ifa_ifu;
+    void *ifa_data;
+
     ifaddrs(ifaddrs* next)
-    : ifa_next(next), ifa_name(NULL), ifa_flags(0), ifa_addr(NULL), ifa_netmask(NULL)
+    : ifa_next(next), ifa_name(NULL), ifa_flags(0), ifa_addr(NULL), ifa_netmask(NULL), ifa_ifu(NULL), ifa_data(NULL)
     {
     }
     ~ifaddrs() {


### PR DESCRIPTION
The original Android Open Source Project implementation of ifaddrs did not include the fields ifa_ifu and ifa_data. These field are present on the Rust side declaration of the structure ifaddrs.

The missing fields were added and are always set to NULL. The Rust side already deals with them being optional.

The structure on the Rust side:

    #[repr(C)]
    pub struct union_ifa_ifu {
        pub data: *mut ::std::os::raw::c_void,
    }
    impl union_ifa_ifu {
        pub fn ifu_broadaddr(&mut self) -> *mut nix::sys::socket::sockaddr {
            self.data as *mut nix::sys::socket::sockaddr
        }
        pub fn ifu_dstaddr(&mut self) -> *mut nix::sys::socket::sockaddr {
            self.data as *mut nix::sys::socket::sockaddr
        }
    }

    #[repr(C)]
    pub struct ifaddrs {
        pub ifa_next: *mut ifaddrs,
        pub ifa_name: *mut ::std::os::raw::c_char,
        pub ifa_flags: ::std::os::raw::c_uint,
        pub ifa_addr: *mut nix::sys::socket::sockaddr,
        pub ifa_netmask: *mut nix::sys::socket::sockaddr,
        pub ifa_ifu: union_ifa_ifu,
        pub ifa_data: *mut ::std::os::raw::c_void,
    }