### PR TITLE
Fixed cross-compil build from Linux to Windows

### DIFF
--- a/src/ifaces/ffi/windows/mod.rs
+++ b/src/ifaces/ffi/windows/mod.rs
@@ -30,7 +30,7 @@ const PREALLOC_ADAPTERS_LEN: usize = 15 * 1024;
 
 use crate::ifaces::{Interface, Kind, NextHop};
 
-#[link(name = "Iphlpapi")]
+#[link(name = "iphlpapi")]
 extern "system" {
     pub fn GetAdaptersAddresses(
         family: ULONG,


### PR DESCRIPTION
`cargo build --target=x86_64-pc-windows-gnu `the linker failed ( /`usr/lib/gcc/x86_64-w64-mingw32/11.2.0/../../../../x86_64-w64-mingw32/bin/ld: cannot find -lIphlpapi)`.

[same issue ](https://github.com/unrelentingtech/systemstat/issues/96)