### PR TITLE
update deps + loosen some requirements

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -10,32 +10,47 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-    name: Build and test
+  check_and_test:
+    name: Check and test
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        toolchain:
+          - 1.56.1 # min supported version (https://github.com/webrtc-rs/webrtc/#toolchain)
+          - stable
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - name: Build
-        run: cargo build --verbose
-      - name: Run tests
-        run: cargo test --verbose
-
-  rustfmt_and_clippy:
-    name: Check rustfmt style && run clippy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.55.0
+          toolchain: ${{ matrix.toolchain }}
+          profile: minimal
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  rustfmt_and_clippy:
+    name: Check rustfmt style and run clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
           profile: minimal
           components: clippy, rustfmt
           override: true
       - name: Cache cargo registry
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
@@ -43,8 +58,28 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
+          args: -- -D warnings
       - name: Check formating
         uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
+
+  minimal_versions:
+    name: Compile and test with minimal versions
+    strategy:
+      matrix:
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly
+            override: true
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: taiki-e/install-action@cargo-minimal-versions
+      - run: cargo minimal-versions check --workspace --all-features --ignore-private -v
+      - run: cargo minimal-versions build --workspace --all-features --ignore-private -v
+      - run: cargo minimal-versions test --workspace --all-features -v

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,22 +21,22 @@ marshal = []
 sync = []
 
 [dependencies]
-tokio = { version = "1.15.0", features = ["full"] }
-lazy_static = "1.4.0"
-async-trait = "0.1.52"
-ipnet = "2.3.1"
-log = "0.4.14"
-rand = "0.8.4"
-bytes = "1.1.0"
-thiserror = "1.0.30"
-parking_lot = "0.11.2"
+tokio = { version = "1.19", features = ["full"] }
+lazy_static = "1.4"
+async-trait = "0.1.56"
+ipnet = "2.5"
+log = "0.4"
+rand = "0.8.5"
+bytes = "1"
+thiserror = "~1.0.2"
+parking_lot = "0.12.1"
 
 [target.'cfg(not(windows))'.dependencies]
-nix = "0.23"
-libc = "0.2.8"
+nix = "0.24.1"
+libc = "0.2.126"
 
 [target.'cfg(windows)'.dependencies]
-bitflags = "1.2.1"
+bitflags = "1.3"
 winapi = { version = "0.3.9", features = [
     "basetsd",
     "guiddef",
@@ -46,10 +46,10 @@ winapi = { version = "0.3.9", features = [
 ] }
 
 [build-dependencies]
-cc = "1.0.72"
+cc = "1.0.73"
 
 [dev-dependencies]
-tokio-test = "0.4.2"
+tokio-test = "0.4.0" # must match the min version of the `tokio` crate above
 env_logger = "0.9.0"
 chrono = "0.4.19"
 criterion = { version = "0.3.5", features = ["stable"]}

--- a/src/conn/conn_bridge.rs
+++ b/src/conn/conn_bridge.rs
@@ -84,8 +84,8 @@ pub struct Bridge {
 impl Bridge {
     pub fn new(
         loss_chance: u8,
-        filter_cb0: Option<Box<dyn Fn(&Bytes) -> bool + Send + Sync>>,
-        filter_cb1: Option<Box<dyn Fn(&Bytes) -> bool + Send + Sync>>,
+        filter_cb0: Option<FilterCbFn>,
+        filter_cb1: Option<FilterCbFn>,
     ) -> (Arc<Bridge>, impl Conn, impl Conn) {
         let (wr_tx0, rd_rx0) = mpsc::channel(1024);
         let (wr_tx1, rd_rx1) = mpsc::channel(1024);

--- a/src/vnet/nat.rs
+++ b/src/vnet/nat.rs
@@ -22,7 +22,7 @@ const DEFAULT_NAT_MAPPING_LIFE_TIME: Duration = Duration::from_secs(30);
 //  - Port Mapping behavior
 //  - Filtering behavior
 // See: https://tools.ietf.org/html/rfc4787
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum EndpointDependencyType {
     // EndpointIndependent means the behavior is independent of the endpoint's address or port
     EndpointIndependent,
@@ -39,7 +39,7 @@ impl Default for EndpointDependencyType {
 }
 
 // NATMode defines basic behavior of the NAT
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum NatMode {
     // NATModeNormal means the NAT behaves as a standard NAPT (RFC 2663).
     Normal,


### PR DESCRIPTION
rules:
- for crates that are below v1.0 -> specify the precise version
- If the code uses a feature that was added for example in X 0.3.17,
  then you should specify 0.3.17, which actually means "0.3.y where y >=
  17"
- for crates the are above or equal v1.0 -> specify only major version
  if the crate's API is minimal and won't change between minor versions
    OR specify major&minor versions otherwise

tested with https://github.com/taiki-e/cargo-minimal-versions